### PR TITLE
升级scrapy1.0版本

### DIFF
--- a/alexa/alexa/pipelines.py
+++ b/alexa/alexa/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -46,5 +46,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/alexa/alexa/spiders/alexa_spider.py
+++ b/alexa/alexa/spiders/alexa_spider.py
@@ -6,12 +6,12 @@ import urllib
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from alexa.items import *

--- a/amazonbook/amazonbook/pipelines.py
+++ b/amazonbook/amazonbook/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -46,5 +46,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/amazonbook/amazonbook/spiders/spider.py
+++ b/amazonbook/amazonbook/spiders/spider.py
@@ -6,12 +6,12 @@ import urllib
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from amazonbook.items import *

--- a/dmoz/dmoz/pipelines.py
+++ b/dmoz/dmoz/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -46,5 +46,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/dmoz/dmoz/spiders/spider.py
+++ b/dmoz/dmoz/spiders/spider.py
@@ -6,12 +6,12 @@ import urllib
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from dmoz.items import *

--- a/doubanbook/doubanbook/pipelines.py
+++ b/doubanbook/doubanbook/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 

--- a/doubanbook/doubanbook/spiders/douban_spider.py
+++ b/doubanbook/doubanbook/spiders/douban_spider.py
@@ -4,12 +4,12 @@ import json
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from doubanbook.items import *
@@ -20,12 +20,12 @@ class DoubanBookSpider(CrawlSpider):
     name = "doubanbook"
     allowed_domains = ["douban.com"]
     start_urls = [
-        "http://book.douban.com/tag/"
+        "https://book.douban.com/tag/"
     ]
     rules = [
-        Rule(sle(allow=("/subject/\d+/\?from=tag$")), callback='parse_2'),
-        Rule(sle(allow=("/tag/[^/]+/\?focus=book$", )), follow=True),
-        Rule(sle(allow=("/tag/$", )), follow=True),
+        Rule(sle(allow=("/subject/\d+$")), callback='parse_2'),
+        Rule(sle(allow=("/tag/[^/]+$", )), follow=True),
+        #Rule(sle(allow=("/tag/$", )), follow=True),
     ]
 
     def parse_2(self, response):
@@ -47,6 +47,9 @@ class DoubanBookSpider(CrawlSpider):
         # url cannot encode to Chinese easily.. XXX
         info('parsed ' + str(response))
 
-    def _process_request(self, request):
+    def process_request(self, request):
         info('process ' + str(request))
         return request
+
+    def closed(self, reason):
+        info("DoubanBookSpider Closed:" + reason)

--- a/doubanmovie/doubanmovie/pipelines.py
+++ b/doubanmovie/doubanmovie/pipelines.py
@@ -24,8 +24,12 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
+        print("JsonWithEncodingPipeline closed")
         self.file.close()
+
+    def open_spider(self, spider):
+        print("JsonWithEncodingPipeline opend")
 
 
 class RedisPipeline(object):
@@ -46,5 +50,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/doubanmovie/doubanmovie/settings.py
+++ b/doubanmovie/doubanmovie/settings.py
@@ -22,7 +22,7 @@ NEWSPIDER_MODULE = 'doubanmovie.spiders'
 #USER_AGENT = 'doubanmovie (+http://www.yourdomain.com)'
 
 DOWNLOADER_MIDDLEWARES = {
-   # 'misc.middleware.CustomHttpProxyMiddleware': 400,
+    #'misc.middleware.CustomHttpProxyMiddleware': 400,
     'misc.middleware.CustomUserAgentMiddleware': 401,
 }
 

--- a/doubanmovie/doubanmovie/spiders/spider.py
+++ b/doubanmovie/doubanmovie/spiders/spider.py
@@ -7,12 +7,12 @@ import pdb
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from doubanmovie.items import *
@@ -24,17 +24,21 @@ class doubanmovieSpider(CommonSpider):
     name = "doubanmovie"
     allowed_domains = ["douban.com"]
     start_urls = [
-        "http://movie.douban.com/chart",
+        #"https://movie.douban.com/tag/",
+        "https://movie.douban.com/chart"
     ]
     rules = [
-        Rule(sle(allow=(".*movie.douban.com/subject/[0-9]+/$")), callback='parse_1', follow=True),
+        #Rule(sle(allow=("/tag/[0-9]{4}$")), follow=True),
+        #Rule(sle(allow=("/tag/[0-9]{4}/?start=[0-9]{2,4}&type=T$")), follow=True),
+        #Rule(sle(allow=("/subject/[0-9]+$")), callback='parse_1'),
+        Rule(sle(allow=("/subject/[0-9]+/$")), callback='parse_1', follow=True),
     ]
 
     list_css_rules = { 
         '.linkto': {
             'url': 'a::attr(href)',
             'name': 'a::text',
-        }   
+        }
     }   
 
     list_css_rules_2 = { 
@@ -54,5 +58,6 @@ class doubanmovieSpider(CommonSpider):
     def parse_1(self, response):
         info('Parse '+response.url)
         x = self.parse_with_rules(response, self.content_css_rules, dict)
-        print(repr(x).decode('raw_unicode_escape'))
+        return x
+        #print(repr(x).decode('raw_unicode_escape'))
         # return self.parse_with_rules(response, self.css_rules, doubanmovieItem)

--- a/googlescholar/googlescholar/pipelines.py
+++ b/googlescholar/googlescholar/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -46,5 +46,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/googlescholar/googlescholar/spiders/spider.py
+++ b/googlescholar/googlescholar/spiders/spider.py
@@ -7,12 +7,12 @@ import pdb
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from googlescholar.items import *

--- a/hrtencent/hrtencent/pipelines.py
+++ b/hrtencent/hrtencent/pipelines.py
@@ -20,5 +20,5 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()

--- a/hrtencent/hrtencent/spiders/hrtencent_spider.py
+++ b/hrtencent/hrtencent/spiders/hrtencent_spider.py
@@ -4,12 +4,12 @@ import json
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from hrtencent.items import *

--- a/linkedin/linkedin/linkedin/spiders/LinkedinSpider.py
+++ b/linkedin/linkedin/linkedin/spiders/LinkedinSpider.py
@@ -1,6 +1,6 @@
 from scrapy.selector import HtmlXPathSelector
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor
-from scrapy.contrib.spiders import CrawlSpider, Rule
+from scrapy.linkextractors.sgml import SgmlLinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 from scrapy.http import Request
 from scrapy import log
 from linkedin.items import LinkedinItem, PersonProfileItem

--- a/misc/proxy.py
+++ b/misc/proxy.py
@@ -5,7 +5,7 @@ If you want to disable it, plz configure settings.py
 PROXIES = [
     #{"ip_port": "127.0.0.1:8087"}, #goagent
     #{"ip_port": "127.0.0.1:8118"}, #tor via privoxy
-    {"ip_port": "43.245.202.120:8080"}, #tor via privoxy
+    {"ip_port": "127.0.0.1:1080"}, #tor via privoxy
 ]
 
 FREE_PROXIES = [

--- a/misc/spider.py
+++ b/misc/spider.py
@@ -12,7 +12,7 @@ except:
     from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
 from scrapy.spiders import CrawlSpider, Rule
-from scrapy.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from .log import *
@@ -102,8 +102,8 @@ class CommonSpider(CrawlSpider):
                     self.traversal(i, nv, item_class, item, items)
 
     DEBUG=True
-    def debug(sth):
-        if DEBUG == True:
+    def debug(self, sth):
+        if self.DEBUG == True:
             print(sth)
 
     def deal_text(self, sel, item, force_1_item, k, v):
@@ -144,7 +144,7 @@ class CommonSpider(CrawlSpider):
 
         items = []
         if item_class != dict:
-            self.traversal(sel, rules, item_class, None, items, force_1_item)
+            self.traversal(sel, rules, item_class, None, items)
         else:
             self.traversal_dict(sel, rules, item_class, None, items, force_1_item)
 

--- a/proxylist/proxylist/pipelines.py
+++ b/proxylist/proxylist/pipelines.py
@@ -31,7 +31,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -76,5 +76,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/proxylist/proxylist/spiders/spider.py
+++ b/proxylist/proxylist/spiders/spider.py
@@ -12,7 +12,7 @@ except:
     from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
 from scrapy.spiders import CrawlSpider, Rule
-from scrapy.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.linkextractors import LinkExtractor as sle
 from scrapy.linkextractors import LinkExtractor as sle
 
 

--- a/qqnews/qqnews/pipelines.py
+++ b/qqnews/qqnews/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -46,5 +46,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/qqnews/qqnews/spiders/spider.py
+++ b/qqnews/qqnews/spiders/spider.py
@@ -4,12 +4,12 @@ import json
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from qqnews.items import *

--- a/sinanews/sinanews/pipelines.py
+++ b/sinanews/sinanews/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -46,5 +46,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/sinanews/sinanews/spiders/spider.py
+++ b/sinanews/sinanews/spiders/spider.py
@@ -7,12 +7,12 @@ import pdb
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from sinanews.items import *

--- a/sis/sis/pipelines.py
+++ b/sis/sis/pipelines.py
@@ -21,5 +21,5 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()

--- a/sis/sis/spiders/sis_spider.py
+++ b/sis/sis/spiders/sis_spider.py
@@ -8,12 +8,12 @@ from urlparse import urljoin
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 from sis.items import *
 from misc.log import *
@@ -37,7 +37,7 @@ class sisSpider(CrawlSpider):
 
     def __init__(self, forum_id=58, digit=1, *args, **kwargs):
         self.start_urls = [self.ip_format % d for d in [int(forum_id)]]
-        self.rules = [Rule(sle(allow=("/forum/forum-" + forum_id + "-[0-9]{," + digit + "}\.html")), follow=True, callback='parse_1'),]
+        self.rules = [Rule(sle(allow=("/forum/forum-" + str(forum_id) + "-[0-9]{," + str(digit) + "}\.html")), follow=True, callback='parse_1'),]
         super(sisSpider, self).__init__(*args, **kwargs)
 
     def parse_2(self, response):

--- a/template/template/pipelines.py
+++ b/template/template/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -46,5 +46,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/template/template/spiders/spider.py
+++ b/template/template/spiders/spider.py
@@ -7,12 +7,12 @@ import pdb
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from template.items import *

--- a/tutorial/tutorial/pipelines.py
+++ b/tutorial/tutorial/pipelines.py
@@ -23,7 +23,7 @@ class XmlExportPipeline(object):
     def from_crawler(cls, crawler):
         pipeline = cls()
         crawler.signals.connect(pipeline.spider_opened, signals.spider_opened)
-        crawler.signals.connect(pipeline.spider_closed, signals.spider_closed)
+        crawler.signals.connect(pipeline.close_spider, signals.close_spider)
         return pipeline
 
     def spider_opened(self, spider):
@@ -32,7 +32,7 @@ class XmlExportPipeline(object):
         self.exporter = XmlItemExporter(file)
         self.exporter.start_exporting()
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.exporter.finish_exporting()
         file = self.files.pop(spider)
         file.close()
@@ -55,5 +55,5 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()

--- a/tutorial/tutorial/spiders/naive_spider.py
+++ b/tutorial/tutorial/spiders/naive_spider.py
@@ -14,13 +14,13 @@ from urlparse import urljoin
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
 from scrapy import log
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from tutorial.items import TutorialItem

--- a/underdev/meijutt/meijutt/pipelines.py
+++ b/underdev/meijutt/meijutt/pipelines.py
@@ -24,7 +24,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -46,5 +46,5 @@ class RedisPipeline(object):
             final_item = dict(item.items() + ritem.items())
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/underdev/meijutt/meijutt/spiders/spider.py
+++ b/underdev/meijutt/meijutt/spiders/spider.py
@@ -7,12 +7,12 @@ import pdb
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from meijutt.items import *

--- a/zhihu/zhihu/pipelines.py
+++ b/zhihu/zhihu/pipelines.py
@@ -27,7 +27,7 @@ class JsonWithEncodingPipeline(object):
         self.file.write(line)
         return item
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         self.file.close()
 
 
@@ -55,5 +55,5 @@ class RedisPipeline(object):
             final_item = item
         self.r.set(item['id'], final_item)
 
-    def spider_closed(self, spider):
+    def close_spider(self, spider):
         return

--- a/zhihu/zhihu/spiders/zhihu_spider.py
+++ b/zhihu/zhihu/spiders/zhihu_spider.py
@@ -7,12 +7,12 @@ from urlparse import urlparse
 
 from scrapy.selector import Selector
 try:
-    from scrapy.spider import Spider
+    from scrapy.spiders import Spider
 except:
-    from scrapy.spider import BaseSpider as Spider
+    from scrapy.spiders import BaseSpider as Spider
 from scrapy.utils.response import get_base_url
-from scrapy.contrib.spiders import CrawlSpider, Rule
-from scrapy.contrib.linkextractors.sgml import SgmlLinkExtractor as sle
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor as sle
 
 
 from zhihu.items import *


### PR DESCRIPTION
在scrapy1.06下运行发现了一些错误和兼容问题， 不知修改能否被接受
 修复：
* [/misc/spider.py#147](https://github.com/geekan/scrapy-examples/pull/9/files#diff-f671b7cc49f360e163a437843daeb772L147) 多了参数force_1_item
* [/misc/spider.py#105](https://github.com/geekan/scrapy-examples/pull/9/files#diff-f671b7cc49f360e163a437843daeb772L105) debug方法缺少self

兼容：
* [/../pipelines.py#27](https://github.com/geekan/scrapy-examples/pull/9/files#diff-e888375c6128699b653b7407a798c421L27) spider_closed改变为close_spider （1.0下spider_closed无法被执行）
*  [/../spiders/spider.py#10](https://github.com/geekan/scrapy-examples/pull/9/files#diff-dd5f49b0328827ffcb2adbbf05d77e55L10) scrapy.spider改变为scrapy.spiders
* [/../spiders/spider.py#10](https://github.com/geekan/scrapy-examples/pull/9/files#diff-dd5f49b0328827ffcb2adbbf05d77e55L14) scrapy.contrib.spiders改变为scrapy.contrib.spiders
* [/../spiders/spider.py#10](https://github.com/geekan/scrapy-examples/pull/9/files#diff-dd5f49b0328827ffcb2adbbf05d77e55L15) scrapy.contrib.linkextractors.sgml改变为scrapy.linkextractors